### PR TITLE
CED-813: handle arbitrary folder structures during migration

### DIFF
--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -23,28 +23,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const filePath = path.join(__dirname, 'migration_plan.csv');
 const data = fs.readFileSync(filePath, 'utf-8');
 const records = parse(data)
-const old_slug_to_data = records.map(record => {
+const old_slug_to_data = records.reduce((result, record) => {
     const oldUrlParts = record[0].split('/')
     const oldSlug = oldUrlParts[oldUrlParts.length - 2]
     const newUrlParts = record[1].split('/')
     const newSlug = newUrlParts[newUrlParts.length - 2]
     const newFolderParts = newUrlParts.slice(3, newUrlParts.length - 2)
-    const newFolder = `/${newFolderParts.join('/')}/`
+    const folder = `/${newFolderParts.join('/')}/`
     const title = record[2].replace(' | EnergySage', '')
     const description = record[3]
-    return [
-        oldSlug,
+    result[oldSlug] = {
         newSlug,
         title,
         description,
-        newFolder,
-    ]
-}).reduce((result, record) => {
-    result[record[0]] = {
-        newSlug: record[1],
-        title: record[2],
-        description: record[3],
-        folder: record[4],
+        folder,
     }
     return result
 }, {})

--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -180,6 +180,17 @@ const getSeoData = (data) => {
     }
 }
 
+export const slugToTitle = (slug) => {
+    if (!slug) {
+        return ''
+    }
+
+    const words = slug.split('-')
+    const title = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+
+    return title
+}
+
 const getArticleBreadcrumbList = (data) => {
     const folders = old_slug_to_data[data.slug].folder.split('/')
     const innerBreadcrumbs = []
@@ -188,7 +199,7 @@ const getArticleBreadcrumbList = (data) => {
         const fullPath = `/${folders.slice(1, i + 1).join('/')}/`
         innerBreadcrumbs.push({
             component: 'ArticleBreadcrumb',
-            name: folder,
+            name: slugToTitle(folder),
             url: {
                 url: fullPath,
                 linktype: 'url',

--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -168,7 +168,7 @@ const getSeoData = (data) => {
         'description': description,
         'og_title': title,
         'og_description': description,
-        'og_image': data.yoast_head_json.og_image.map(entry => entry.url),
+        'og_image': data.yoast_head_json.og_image?.map(entry => entry.url),
     }
 }
 

--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -152,7 +152,7 @@ const getTitle = (data) => {
 }
 
 const getPath = (data) => {
-    return `/blog/${data.slug}/`
+    return `${old_slug_to_data[data.slug].folder}${data.slug}/`
 }
 
 const getRealPath = (data) => {
@@ -181,6 +181,22 @@ const getSeoData = (data) => {
 }
 
 const getArticleBreadcrumbList = (data) => {
+    const folders = old_slug_to_data[data.slug].folder.split('/')
+    const innerBreadcrumbs = []
+    for (let i = 1; i < folders.length - 1; i++) {
+        const folder = folders[i]
+        const fullPath = `/${folders.slice(1, i + 1).join('/')}/`
+        innerBreadcrumbs.push({
+            component: 'ArticleBreadcrumb',
+            name: folder,
+            url: {
+                url: fullPath,
+                linktype: 'url',
+                fieldtype: 'multilink',
+                cached_url: fullPath,
+            },
+        })
+    }
     return [{
         component: 'ArticleBreadcrumbList',
         breadcrumbList: [
@@ -194,24 +210,15 @@ const getArticleBreadcrumbList = (data) => {
                     cached_url: '/',
                 },
             },
-            {
-                component: 'ArticleBreadcrumb',
-                name: 'Blog',
-                url: {
-                    url: '/blog/',
-                    linktype: 'url',
-                    fieldtype: 'multilink',
-                    cached_url: '/blog/',
-                },
-            },
+            ...innerBreadcrumbs,
             {
                 component: 'ArticleBreadcrumb',
                 name: old_slug_to_data[data.slug].title,
                 url: {
-                    url: `/${getPath(data)}`,
+                    url: getPath(data),
                     linktype: 'url',
                     fieldtype: 'multilink',
-                    cached_url: `/${getPath(data)}`,
+                    cached_url: getPath(data),
                 }
             },
         ],

--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -28,6 +28,8 @@ const old_slug_to_data = records.map(record => {
     const oldSlug = oldUrlParts[oldUrlParts.length - 2]
     const newUrlParts = record[1].split('/')
     const newSlug = newUrlParts[newUrlParts.length - 2]
+    const newFolderParts = newUrlParts.slice(3, newUrlParts.length - 2)
+    const newFolder = `/${newFolderParts.join('/')}/`
     const title = record[2].replace(' | EnergySage', '')
     const description = record[3]
     return [
@@ -35,12 +37,14 @@ const old_slug_to_data = records.map(record => {
         newSlug,
         title,
         description,
+        newFolder,
     ]
 }).reduce((result, record) => {
     result[record[0]] = {
         newSlug: record[1],
         title: record[2],
         description: record[3],
+        folder: record[4],
     }
     return result
 }, {})
@@ -314,6 +318,11 @@ const getArticleToc = (data) => {
     }]
 }
 
+const getFolder = (wp_entry) => {
+    const entryData = old_slug_to_data[wp_entry.slug]
+    return entryData.folder
+}
+
 const wp2storyblok = new Wp2Storyblok(`${process.env.WP_BASE_URL}/wp-json`, slugs, {
     token: process.env.STORYBLOK_OAUTH_TOKEN, // My Account > Personal access tokens
     space_id: process.env.STORYBLOK_SPACE_ID, // Settings
@@ -369,7 +378,7 @@ const wp2storyblok = new Wp2Storyblok(`${process.env.WP_BASE_URL}/wp-json`, slug
         {
             name: 'posts', // Post type name in WP
             new_content_type: 'ArticlePage001', // Content Type name in Storyblok
-            folder: '/blog/', // Destination folder name in Storyblok
+            folder: getFolder,
             schema_mapping: new Map([
                 ["date", "first_published_at"],
                 [getTitle, "name"],

--- a/src/migration.js
+++ b/src/migration.js
@@ -106,9 +106,18 @@ export default class Wp2Storyblok {
         const wp_entry = this.wp.content_types[content_type.name][j]
         // If a folder is set as destination of the stories, update the link property from WP to have
         // the new folder in it
-        if (content_type.folder) {
+        const content_type_folder = content_type.folder
+        if (content_type_folder) {
+          let folder
+          if (typeof content_type_folder === "string") {
+            folder = content_type_folder
+          } else if (typeof content_type_folder === 'function') {
+            folder = content_type_folder(wp_entry)
+          } else {
+            throw "Expected string or function for 'folder'"
+          }
           const entry_url = new URL(wp_entry.link)
-          wp_entry.link = wp_entry.link.replace(entry_url.origin, `${entry_url.origin}/${content_type.folder.replace(/^\//, '').replace(/\/$/, '')}`)
+          wp_entry.link = wp_entry.link.replace(entry_url.origin, `${entry_url.origin}/${folder.replace(/^\//, '').replace(/\/$/, '')}`)
         }
         // Basic data object for Storyblok
         // Temporary properties for managing folders of imported content

--- a/src/migration.js
+++ b/src/migration.js
@@ -4,6 +4,7 @@ import Storyblok from './storyblok.js'
 import { compareSlugs } from './utils.js'
 import Wp from './wp.js'
 import {convert} from "html-to-text";
+import {slugToTitle} from "../migrateWPtoStoryblok.js";
 const { markdownToRichtext } = pkg
 
 export const turndownService = new TurndownService()
@@ -143,7 +144,7 @@ export default class Wp2Storyblok {
           // If the folder of the current file is not yet in the list of the ones to migrate, it gets added
           if (!this.folders_to_migrate.find(f => f.path === sb_entry['_wp_folder']) && !sb_links.folders.find(f => compareSlugs(f.slug, sb_entry['_wp_folder']))) {
             const folder_slug = sb_entry['_wp_folder'].split('/')[sb_entry['_wp_folder'].split('/').length - 2]
-            this.folders_to_migrate.push({ path: sb_entry['_wp_folder'], name: folder_slug.replace(/-_/g, ' '), slug: folder_slug })
+            this.folders_to_migrate.push({ path: sb_entry['_wp_folder'], name: slugToTitle(folder_slug), slug: folder_slug })
           }
         } catch (err) {
           console.log(`Invalid URL for entry ${sb_entry.name}`)
@@ -224,7 +225,7 @@ export default class Wp2Storyblok {
           const folder_slug = this.folders_to_migrate[j].parent.split('/')[this.folders_to_migrate[j].parent.split('/').length - 2]
           this.folders_to_migrate.push({
             path: this.folders_to_migrate[j].parent,
-            name: folder_slug,
+            name: slugToTitle(folder_slug),
             slug: folder_slug
           })
         }

--- a/src/storyblok.js
+++ b/src/storyblok.js
@@ -206,11 +206,15 @@ export default class Storyblok {
     let created_folders = []
     const links = await this.getLinks()
     for (let i = 0; i < folders.length; i++) {
+      let path = `${folders[i].slug}/`
+      if (folders[i].path.split('/').length < 4) {  // In this case we're only one folder level deep
+        path = `/${path}`
+      }
       let payload = {
         story: {
           name: folders[i].name,
           slug: folders[i].slug,
-          path: `/${folders[i].slug}/`,
+          path: path,
           is_folder: true
         }
       }


### PR DESCRIPTION
Rather than being hardcoded to go to `/blog/`, the migration plan is now used to determine the correct folder path for the stories to go.

Jira ticket: https://energysage.atlassian.net/browse/CED-813