### PR TITLE
fix: incorrect copyEditedBy and copyWrittenBy text

### DIFF
--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -346,8 +346,8 @@ const getArticleEeat = async (data) => {
         lede: lede,
         // It's annoying that default values have to be manually copied
         copyTooltipSuccess: 'Link copied!',
-        copyWrittenBy: 'Written By: {authors}',
-        copyEditedBy: 'Edited By: {authorName}',
+        copyWrittenBy: 'Written by: {authors}',
+        copyEditedBy: 'Edited by: {editor}',
         copyUpdated: 'Updated {updatedDate}',
         copyPublished: 'Published {publishDate}',
         copyReadTimeMinutes: '{num} min read',


### PR DESCRIPTION
Fixes incorrect token name causing rendering issue and sentence case capitalization.
https://energysage.atlassian.net/browse/CED-851
