### PR TITLE
fix: removed no-longer-necessary article title from breadcrumbs

### DIFF
--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -247,16 +247,6 @@ const getArticleBreadcrumbList = (data) => {
                 },
             },
             ...innerBreadcrumbs,
-            {
-                component: 'ArticleBreadcrumb',
-                name: getTitle(data, true),
-                url: {
-                    url: getPath(data),
-                    linktype: 'url',
-                    fieldtype: 'multilink',
-                    cached_url: getPath(data),
-                }
-            },
         ],
     }]
 }


### PR DESCRIPTION
We are no longer adding a link to the article itself with the article titile as the name for the last breadcrumb; we are only showing the chain parent folders. This PR removes that final breadcrumb of the article title.