### PR TITLE
fix: removed no-longer-used canonicalUrl field from ArticleEeat

### DIFF
--- a/migrateWPtoStoryblok.js
+++ b/migrateWPtoStoryblok.js
@@ -371,13 +371,6 @@ const getArticleEeat = async (data) => {
         // This has been removed from Storyblok temporarily(?)
         // editorialGuidelines: process.env.EDITORIAL_GUIDELINES_UUID,
         legacyUpdatedDate: `${(new Date(data.modified)).toISOString().slice(0, 10)} 00:00`,
-        canonicalUrl: {
-            id: '',
-            url: url,
-            linktype: 'url',
-            fieldtype: 'multilink',
-            cached_url: url,
-        },
         category: categorySlugs,
         lede: lede,
         // It's annoying that default values have to be manually copied


### PR DESCRIPTION
<!-- Add a title with the Jira ticket and purpose, e.g. "TICKET_NUMBER Awesome new feature". -->

<!-- Uncomment this if it's relevant. -->
<!-- **TIME SENSITIVE.** Deploy by: -->

## Related Jira Tickets
<!-- Link to the ticket for this work (e.g. https://energysage.atlassian.net/browse/TICKET_NUMBER) and any other related tickets. -->
-

## Changes
<!-- Describe your work in detail. -->
- We no longer use the `canonicalUrl` field in ArticleEeat, so this PR removes it to avoid extra unnecessary out-of-schema data in migrated content.

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->

-

## Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

-

### How to run locally
<!-- Include any instructions and/or links to docs to help reviewers see your work in their dev environments. -->

-

## Remaining TODOs
<!-- Is there additional work to be done prior to merge/deployment, or in a subsequent PR? -->

- [ ]
